### PR TITLE
Roost “Pay Rent” screen changes

### DIFF
--- a/i18n/en-US.json
+++ b/i18n/en-US.json
@@ -106,5 +106,6 @@
     "addDai": "Add DAI",
     "withdrawDAI": "Withdraw DAI",
     "sendToCashMode": "Send to cash mode",
-    "your_home": "Your Home"
+    "your_home": "Your Home",
+    "pay_rent": "Pay Rent"
 }

--- a/lib/generated/i18n.dart
+++ b/lib/generated/i18n.dart
@@ -248,6 +248,8 @@ class I18n implements WidgetsLocalizations {
   String get sendToCashMode => "Send to cash mode";
   /// "Your Home"
   String get your_home => "Your Home";
+  /// "Pay Rent"
+  String get pay_rent => "Pay Rent";
 }
 
 class _I18n_en_US extends I18n {

--- a/lib/screens/buy/buy.dart
+++ b/lib/screens/buy/buy.dart
@@ -45,7 +45,7 @@ class BuyScreen extends StatelessWidget {
               //   ),
               // ],
               automaticallyImplyLeading: false,
-              title: I18n.of(context).buy,
+              title: I18n.of(context).pay_rent,
               children: <Widget>[BusinessesListView()]);
         });
   }

--- a/lib/screens/buy/buy.dart
+++ b/lib/screens/buy/buy.dart
@@ -46,7 +46,10 @@ class BuyScreen extends StatelessWidget {
               // ],
               automaticallyImplyLeading: false,
               title: I18n.of(context).pay_rent,
-              children: <Widget>[BusinessesListView()]);
+              children: <Widget>[
+                RoostPaymentHelpView(),
+                BusinessesListView()
+              ]);
         });
   }
 }
@@ -197,5 +200,27 @@ class BusinessesListView extends StatelessWidget {
                   ),
                 );
         });
+  }
+}
+
+class RoostPaymentHelpView extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.only(top: 40, right: 40, left: 40),
+      child: new Column(
+        children: <Text>[
+          Text(
+            'Not yet renting through Roost?',
+            textAlign: TextAlign.center,
+            style: TextStyle(fontWeight: FontWeight.bold),
+          ),
+          Text(
+            'Contact leon@roostnow.co.uk',
+            textAlign: TextAlign.center
+          ),
+        ],
+      ),
+    );
   }
 }

--- a/lib/screens/cash_home/cash_mode.dart
+++ b/lib/screens/cash_home/cash_mode.dart
@@ -73,7 +73,7 @@ class _CashModeScaffoldState extends State<CashModeScaffold> {
                 items: [
                   bottomBarItem(I18n.of(context).home, 'home'),
                   bottomBarItem(I18n.of(context).your_home, 'home'),
-                  bottomBarItem(I18n.of(context).buy, 'rent'),
+                  bottomBarItem(I18n.of(context).pay_rent, 'rent'),
                   // bottomBarItem(I18n.of(context).receive, 'receive'),
                 ],
               ));

--- a/lib/screens/cash_home/cash_mode.dart
+++ b/lib/screens/cash_home/cash_mode.dart
@@ -71,7 +71,7 @@ class _CashModeScaffoldState extends State<CashModeScaffold> {
                 backgroundColor: Theme.of(context).bottomAppBarColor,
                 showUnselectedLabels: true,
                 items: [
-                  bottomBarItem(I18n.of(context).home, 'home'),
+                  bottomBarItem(I18n.of(context).wallet, 'receive'),
                   bottomBarItem(I18n.of(context).your_home, 'home'),
                   bottomBarItem(I18n.of(context).pay_rent, 'rent'),
                   // bottomBarItem(I18n.of(context).receive, 'receive'),


### PR DESCRIPTION
Hi chaps! A few fixes to:

1. Implement the “Pay Rent” toolbar label that was accidentally lost during the merge of https://github.com/fuseio/fuse-wallet/pull/197
2. Add some Roost-specific help text above the list of "businesses" on the "Pay Rent" (aka "Buy") screen.
3. Tweak the icon and label for the "Home" toolbar item, to avoid confusion with the "Your Home" webview item.

Please let me know if the way I‘ve implemented this changes will cause future headaches with rebases, and we can try and work out whether there are better ways for us to override segments of the core code in our fork.

![Screen Shot 2020-05-28 at 17 59 28](https://user-images.githubusercontent.com/739624/83171321-d77a8880-a10d-11ea-8065-c31492cfcb89.png)
