### PR TITLE
Fix: Double parse of WalletUpgrade json response

### DIFF
--- a/lib/redux/actions/user_actions.dart
+++ b/lib/redux/actions/user_actions.dart
@@ -706,13 +706,11 @@ ThunkAction checkWalletUpgrades() {
     try {
       String walletAddress = store.state.userState.walletAddress;
       if (walletAddress.isNotEmpty) {
-        final List<dynamic> response = await chargeApi.getAvailableUpgrades(
+        final List<WalletUpgrade> walletUpgrades =
+            await chargeApi.getAvailableUpgrades(
           walletAddress,
         );
-        final List<WalletUpgrade> walletUpgrades =
-            WalletUpgrade.walletUpgradesFromJson(
-          response,
-        );
+
         if (walletUpgrades.isNotEmpty) {
           store.dispatch(ToggleUpgrade(value: true));
         }
@@ -739,7 +737,7 @@ ThunkAction installWalletUpgrades(
   return (Store store) async {
     try {
       String walletAddress = store.state.userState.walletAddress;
-      final List<dynamic> walletUpgrades =
+      final List<WalletUpgrade> walletUpgrades =
           await chargeApi.getAvailableUpgrades(walletAddress);
       if (walletUpgrades.isNotEmpty) {
         final WalletUpgrade walletUpgrade = walletUpgrades.first;

--- a/lib/redux/actions/user_actions.dart
+++ b/lib/redux/actions/user_actions.dart
@@ -739,10 +739,8 @@ ThunkAction installWalletUpgrades(
   return (Store store) async {
     try {
       String walletAddress = store.state.userState.walletAddress;
-      final List<dynamic> response =
+      final List<dynamic> walletUpgrades =
           await chargeApi.getAvailableUpgrades(walletAddress);
-      final List<WalletUpgrade> walletUpgrades =
-          WalletUpgrade.walletUpgradesFromJson(response);
       if (walletUpgrades.isNotEmpty) {
         final WalletUpgrade walletUpgrade = walletUpgrades.first;
         final Map<String, dynamic> installUpgradeJob =


### PR DESCRIPTION
## Proposed changes

Fixes a parsing issue for Wallet Upgrades, previously used to double parse (once from chargeAPI, and once within the action). This lead to a list with zero items, which lead to no wallet upgrades

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [X ] Bugfix (non-breaking change which fixes an issue)
- [ ] Refactor or a modification (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
